### PR TITLE
Wait for child processes to exit before exiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,18 +27,18 @@ const cpSidechain = childProcess.spawn('geth', [
   '--ws.addr', eth0Address,
   '--ws.port', '8548',
 	'--port', '30304',
-	'--targetgaslimit', '1000000000',
 	'--nodiscover',
 	'--syncmode', 'full',
 	'--networkid', sidechainNetworkId + '',
-	'--etherbase', '0x' + accountRinkebyJson.address,
 	'--allow-insecure-unlock',
 	'--unlock', '0x' + accountRinkebyJson.address,
 	'--password', './password',
 ].concat(isMiner ? [
   '--mine',
-	'--minerthreads', '1',
+	'--miner.threads', '1',
+	'--miner.etherbase', '0x' + accountRinkebyJson.address,
 	'--miner.gasprice', '0',
+	'--miner.gaslimit', '1000000000',
 ] : []));
 cpSidechain.stdout.pipe(process.stdout);
 cpSidechain.stderr.pipe(process.stderr);
@@ -63,18 +63,18 @@ const cpMainnet = childProcess.spawn('geth', [
   '--ws.addr', eth0Address,
   '--ws.port', '8547',
 	'--port', '30303',
-	'--targetgaslimit', '1000000000',
 	'--nodiscover',
 	'--syncmode', 'full',
 	'--networkid', mainnetNetworkId + '',
-	'--etherbase', '0x' + accountMainnetJson.address,
 	'--allow-insecure-unlock',
 	'--unlock', '0x' + accountMainnetJson.address,
 	'--password', './password',
 ].concat(isMiner ? [
   '--mine',
-	'--minerthreads', '1',
+	'--miner.threads', '1',
+	'--miner.etherbase', '0x' + accountMainnetJson.address,
 	'--miner.gasprice', '0',
+	'--miner.gaslimit', '1000000000',
 ] : []));
 cpMainnet.stdout.pipe(process.stdout);
 cpMainnet.stderr.pipe(process.stderr);

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ cpMainnet.stderr.pipe(fs.createWriteStream('./mainnet-stderr.log', {
 }));
 
 const childProcesses = [
-  // cpSidechain,
+  cpSidechain,
   cpMainnet,
 ];
 

--- a/index.js
+++ b/index.js
@@ -94,9 +94,26 @@ const childProcesses = [
   'SIGINT',
   'SIGTERM',
 ].forEach(s => {
-  process.on(s, signal => {
+  process.on(s, async signal => {
 		for (const cp of childProcesses) {
 	    cp.kill(s);
+
+      await waitForKill(cp);
 	  }
 	});
 });
+
+async function waitForKill(childProcess, cycle = 100) {
+  let resolve;
+  const promise = new Promise(r => resolve = r);
+
+  setInterval(() => {
+    try {
+      process.kill(cp.pid, 0);
+    } catch(e) {
+      resolve();
+    }
+  }, cycle);
+
+  return promise;
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "sudo $(which node) $(which forever) start -a -l forever.log -o stdout.log -e stderr.log index.js",
+    "stop": "sudo $(which node) $(which forever) stop index.js",
     "clear": "rm -Rf /home/ubuntu/.ethereum/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This patch waits for each child process to close, and also takes care of a dangling rinkeby process.